### PR TITLE
Potential fix for code scanning alert no. 33: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "nodemailer": "^6.9.16",
     "nodemon": "^3.1.7",
     "stripe": "^17.1.0",
-    "validator": "^13.12.0"
+    "validator": "^13.12.0",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/backend/routes/orderRoute.js
+++ b/backend/routes/orderRoute.js
@@ -1,13 +1,19 @@
 import express from "express"
 import authMiddleware from './../middleware/auth.js';
 import { placeOrder, verifyOrder, userOrders,listOrders,updateStatus } from "../controllers/orderController.js";
+import rateLimit from 'express-rate-limit';
 
 const orderRouter = express.Router();
+
+const updateStatusLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
 
 orderRouter.post("/place",authMiddleware,placeOrder);
 orderRouter.post("/verify", verifyOrder)
 orderRouter.post("/userorders",authMiddleware,userOrders)
 orderRouter.get('/list',listOrders)
-orderRouter.post('/status', updateStatus)
+orderRouter.post('/status', updateStatusLimiter, updateStatus)
 
 export default orderRouter;


### PR DESCRIPTION
Potential fix for [https://github.com/FlashSpeedie/Swad-v7/security/code-scanning/33](https://github.com/FlashSpeedie/Swad-v7/security/code-scanning/33)

To fix the problem, we need to introduce rate limiting to the `updateStatus` route handler. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting for specific routes. We will import the `express-rate-limit` package, create a rate limiter with appropriate settings, and apply it to the `updateStatus` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
