### PR TITLE
Potential fix for code scanning alert no. 31: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "nodemailer": "^6.9.16",
     "nodemon": "^3.1.7",
     "stripe": "^17.1.0",
-    "validator": "^13.12.0"
+    "validator": "^13.12.0",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/backend/routes/orderRoute.js
+++ b/backend/routes/orderRoute.js
@@ -1,12 +1,18 @@
 import express from "express"
 import authMiddleware from './../middleware/auth.js';
 import { placeOrder, verifyOrder, userOrders,listOrders,updateStatus } from "../controllers/orderController.js";
+import rateLimit from 'express-rate-limit';
 
 const orderRouter = express.Router();
 
+const userOrdersLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
 orderRouter.post("/place",authMiddleware,placeOrder);
 orderRouter.post("/verify", verifyOrder)
-orderRouter.post("/userorders",authMiddleware,userOrders)
+orderRouter.post("/userorders",authMiddleware,userOrdersLimiter,userOrders)
 orderRouter.get('/list',listOrders)
 orderRouter.post('/status', updateStatus)
 


### PR DESCRIPTION
Potential fix for [https://github.com/FlashSpeedie/Swad-v7/security/code-scanning/31](https://github.com/FlashSpeedie/Swad-v7/security/code-scanning/31)

To fix the problem, we need to introduce rate limiting to the `userOrders` route handler to prevent potential denial-of-service attacks. The best way to achieve this is by using the `express-rate-limit` middleware. This middleware allows us to set a maximum number of requests that a client can make within a specified time window.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `backend/routes/orderRoute.js` file.
3. Create a rate limiter with appropriate settings.
4. Apply the rate limiter to the `userOrders` route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
